### PR TITLE
Improve Hit Rate of Truth Version Guess

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,13 +114,13 @@ def guess(end_if_true=False, max_try=10):
         old_version = initial_version
     last_ver = old_version.get("TruthVersion")
     logging.info(f"Last Version: {last_ver}")
-    big, small = int(last_ver[:5]), int(last_ver[6:]) + 1
+    big, small = int(last_ver[:4]), int(last_ver[6:]) + 1
     try_count = 0
     while try_count < max_try:
-        if _validate(f"{big:05d}0{small:02d}"):
+        if _validate(f"{big:04d}00{small:02d}"):
             if end_if_true:
                 break
-        if small >= 20:
+        if try_count == (max_try // 2):
             big += 1
             small = 0
         else:


### PR DESCRIPTION

The existing `guess()` has at least two issues:


### (1) Wrong Digits of Major Version

Major version (variable `big`) should be the first 4 digits rather than 5. For example, 000**8**0040 may be followed by 000**9**0001 but not 0008**1**001.

You can see similar mechanism adopted by https://github.com/Expugn/priconne-database/blob/master/src/check-for-updates.js#L275.

BTW, this is also the root cause why automation bot losses its context every time the major version bumps (and need your attention to update `version.json` manually):

* https://github.com/TragicLifeHu/ReDiveMasterData-TW/commit/85fb3210be87b4afda2feb8d7fed3305c1696cb9
* https://github.com/TragicLifeHu/ReDiveMasterData-TW/commit/d6a4abeeea80c5ac957d3f866f4f54e227bc4067


### (2) Incorrect Ceiling for Minor Version

Minor version can easily exceed `20`. Above (00080040) is a sample having `big = 8` and `small = 40`. The condition `if small >= 20:` is reducing the overall hit rate.

Instead of hard-coding the limit of minor version, reserving half of the trials for the "next" major version could be a simple and better solution.
